### PR TITLE
Make default binding name optional

### DIFF
--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -147,8 +147,8 @@ func (p *Plugin) Generate() ([]byte, error) {
 			policyConfs = append(policyConfs, &p.Policies[i])
 		}
 
-		// If there is more than one policy but no default binding name specified,
-		// throw an error
+		// If there is more than one policy associated with a placement rule but no default binding name
+		// specified, throw an error
 		if len(policyConfs) > 1 && p.PlacementBindingDefaults.Name == "" {
 			return nil, fmt.Errorf(
 				"placementBindingDefaults.name must be set but is empty (mutiple policies were found for the PlacementBinding to placement '%s')",

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -141,20 +141,35 @@ func (p *Plugin) Generate() ([]byte, error) {
 
 	plcBindingCount := 0
 	for plrName, policyIdxs := range plrNameToPolicyIdxs {
-		plcBindingCount++
 		// Determine which policies to be included in the placement binding.
 		policyConfs := []*policyConfig{}
 		for _, i := range policyIdxs {
 			policyConfs = append(policyConfs, &p.Policies[i])
 		}
 
-		// If there are multiple policies, still use the default placement binding name
-		// but append a number to it so it's a unique name.
+		// If there is more than one policy but no default binding name specified,
+		// throw an error
+		if len(policyConfs) > 1 && p.PlacementBindingDefaults.Name == "" {
+			return nil, fmt.Errorf(
+				"placementBindingDefaults.name must be set but is empty (mutiple policies were found for the PlacementBinding to placement '%s')",
+				plrName,
+			)
+		}
+
 		var bindingName string
-		if plcBindingCount == 1 {
-			bindingName = p.PlacementBindingDefaults.Name
+		// If there is only one policy, use the policy name if there is no default
+		// binding name specified
+		if len(policyConfs) == 1 && p.PlacementBindingDefaults.Name == "" {
+			bindingName = "binding-" + policyConfs[0].Name
 		} else {
-			bindingName = fmt.Sprintf("%s%d", p.PlacementBindingDefaults.Name, plcBindingCount)
+			plcBindingCount++
+			// If there are multiple policies, use the default placement binding name
+			// but append a number to it so it's a unique name.
+			if plcBindingCount == 1 {
+				bindingName = p.PlacementBindingDefaults.Name
+			} else {
+				bindingName = fmt.Sprintf("%s%d", p.PlacementBindingDefaults.Name, plcBindingCount)
+			}
 		}
 
 		err := p.createPlacementBinding(bindingName, plrName, policyConfs)
@@ -175,10 +190,6 @@ func (p *Plugin) applyDefaults() {
 	}
 
 	// Set defaults to the defaults that aren't overridden
-	if p.PlacementBindingDefaults.Name == "" && len(p.Policies) == 1 {
-		p.PlacementBindingDefaults.Name = "binding-" + p.Policies[0].Name
-	}
-
 	if p.PolicyDefaults.Categories == nil {
 		p.PolicyDefaults.Categories = defaults.Categories
 	}
@@ -251,12 +262,6 @@ func (p *Plugin) applyDefaults() {
 // assertValidConfig verifies that the user provided configuration has all the
 // required fields. Note that this should be run only after applyDefaults is run.
 func (p *Plugin) assertValidConfig() error {
-	if p.PlacementBindingDefaults.Name == "" && len(p.Policies) > 1 {
-		return errors.New(
-			"placementBindingDefaults.name must be set when there are mutiple policies",
-		)
-	}
-
 	if p.PolicyDefaults.Namespace == "" {
 		return errors.New("policyDefaults.namespace is empty but it must be set")
 	}

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -169,7 +169,7 @@ policies:
 	}
 
 	assertEqual(t, p.Metadata.Name, "policy-generator-name")
-	assertEqual(t, p.PlacementBindingDefaults.Name, "binding-policy-app-config")
+	assertEqual(t, p.PlacementBindingDefaults.Name, "")
 	assertReflectEqual(t, p.PolicyDefaults.Categories, []string{"CM Configuration Management"})
 	assertEqual(t, p.PolicyDefaults.ComplianceType, "musthave")
 	assertReflectEqual(t, p.PolicyDefaults.Controls, []string{"CM-2 Baseline Configuration"})
@@ -197,33 +197,6 @@ policies:
 	assertEqual(t, policy.RemediationAction, "inform")
 	assertEqual(t, policy.Severity, "low")
 	assertReflectEqual(t, policy.Standards, []string{"NIST SP 800-53"})
-}
-
-func TestConfigNoPlacementBindingName(t *testing.T) {
-	t.Parallel()
-	const config = `
-apiVersion: policy.open-cluster-management.io/v1
-kind: PolicyGenerator
-metadata:
-  name: policy-generator-name
-policyDefaults:
-  namespace: my-policies
-policies:
-- name: policy-app-config
-  manifests:
-    - path: input/configmap.yaml
-- name: policy-app-config2
-  manifests:
-    - path: input/configmap2.yaml
-`
-	p := Plugin{}
-	err := p.Config([]byte(config))
-	if err == nil {
-		t.Fatal("Expected an error but did not get one")
-	}
-
-	expected := "placementBindingDefaults.name must be set when there are mutiple policies"
-	assertEqual(t, err.Error(), expected)
 }
 
 func TestConfigNoNamespace(t *testing.T) {


### PR DESCRIPTION
Rather than running an initial validation on the `placementBindingDefaults.name`, this moves the logic deeper, leveraging the new placement flows to determine whether a default binding name is strictly necessary.