### PR TITLE
Add support for automatically informing on Kyverno policy violations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ PolicyGenerator
 vendor/
 
 .go/
+
+# IDE
+.vscode

--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -36,8 +36,8 @@ policyDefaults:
     # file. If given, this placement rule will be used by all policies by default. (See
     # clusterSelectors to generate a new Placement instead.)
     placementRulePath: ""
-  # Optional. The remediation action ("inform" or "enforce") for the policy. This defaults to
-  # "inform".
+  # Optional. The remediation action ("inform" or "enforce") for each configuration policy. This
+  # defaults to "inform".
   remediationAction: "inform"
   # Optional. The severity of the policy violation. This defaults to "low".
   severity: "low"

--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -21,6 +21,10 @@ policyDefaults:
   # annotation. This defaults to ["CM-2 Baseline Configuration"].
   controls:
     - "CM-2 Baseline Configuration"
+  # Optional. When the policy references a Kyverno policy manifest, this determines if an additonal
+  # configuration policy should be generated in order to receive policy violations in Open Cluster
+  # Management when the Kyverno policy has been violated. This defaults to true.
+  informKyvernoPolicies: true
   # Required. The namespace of all the policies.
   namespace: ""
   # Optional. The placement configuration for the policies. This defaults to a placement
@@ -85,6 +89,8 @@ policies:
       - "CM-2 Baseline Configuration"
     # Optional. (See policyDefaults.disabled for description.)
     disabled: false
+    # Optional. (See policyDefaults.informKyvernoPolicies for description.)
+    informKyvernoPolicies: true
     # Optional. Determines the list of namespaces to check on the cluster for the given manifest. If
     # a namespace is specified in the manifest, the selector is not necessary. This defaults to no
     # selectors.

--- a/examples/input3/kyverno.yaml
+++ b/examples/input3/kyverno.yaml
@@ -1,0 +1,18 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-labels
+spec:
+  validationFailureAction: audit
+  rules:
+  - name: check-for-labels
+    match:
+      resources:
+        kinds:
+        - Pod
+    validate:
+      message: "The label `friends-character` is required."
+      pattern:
+        metadata:
+          labels:
+            friends-character: "?*"

--- a/examples/policyGenerator.yaml
+++ b/examples/policyGenerator.yaml
@@ -43,3 +43,7 @@ policies:
             namespace: default
             labels:
               monica: geller
+- name: policy-require-labels
+  disabled: true
+  manifests:
+    - path: input3/

--- a/internal/expanders/expanders.go
+++ b/internal/expanders/expanders.go
@@ -1,0 +1,24 @@
+// Copyright Contributors to the Open Cluster Management project
+package expanders
+
+import (
+	"github.com/open-cluster-management/policy-generator-plugin/internal/types"
+)
+
+func GetExpanders() map[string]Expander {
+	return map[string]Expander{
+		"kyverno": KyvernoPolicyExpander{},
+	}
+}
+
+type Expander interface {
+	CanHandle(manifest map[string]interface{}) bool
+	Enabled(policyConf *types.PolicyConfig) bool
+	Expand(manifest map[string]interface{}, severity string) []map[string]map[string]interface{}
+}
+
+// Common constants for the expanders.
+const (
+	configPolicyAPIVersion = "policy.open-cluster-management.io/v1"
+	configPolicyKind       = "ConfigurationPolicy"
+)

--- a/internal/expanders/kyverno.go
+++ b/internal/expanders/kyverno.go
@@ -1,0 +1,101 @@
+// Copyright Contributors to the Open Cluster Management project
+package expanders
+
+import (
+	"fmt"
+
+	"github.com/open-cluster-management/policy-generator-plugin/internal/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type KyvernoPolicyExpander struct{}
+
+const (
+	kyvernoAPIVersion             = "kyverno.io/v1"
+	kyvernoClusterKind            = "ClusterPolicy"
+	kyvernoPolicyReportAPIVersion = "wgpolicyk8s.io/v1alpha2"
+	kyvernoNamespacedKind         = "Policy"
+)
+
+// CanHandle determines if the manifest is a Kyverno policy that can be expanded.
+func (k KyvernoPolicyExpander) CanHandle(manifest map[string]interface{}) bool {
+	if a, _, _ := unstructured.NestedString(manifest, "apiVersion"); a != kyvernoAPIVersion {
+		return false
+	}
+
+	kind, _, _ := unstructured.NestedString(manifest, "kind")
+	if kind != kyvernoClusterKind && kind != kyvernoNamespacedKind {
+		return false
+	}
+
+	if n, _, _ := unstructured.NestedString(manifest, "metadata", "name"); n == "" {
+		return false
+	}
+
+	return true
+}
+
+// Enabled determines if the policy configuration allows a Kyverno policy to be expanded.
+func (k KyvernoPolicyExpander) Enabled(policyConf *types.PolicyConfig) bool {
+	return policyConf.InformKyvernoPolicies
+}
+
+// AdditionalPolicyTemplates will generate additional policy templates for the Kyverno policy
+// for auditing purposes through Open Cluster Management. This should be run after the CanHandle
+// method.
+func (k KyvernoPolicyExpander) Expand(
+	manifest map[string]interface{}, severity string,
+) []map[string]map[string]interface{} {
+	templates := []map[string]map[string]interface{}{}
+	// This was previously validated in the CanHandle method.
+	policyName, _, _ := unstructured.NestedString(manifest, "metadata", "name")
+
+	configPolicyName := fmt.Sprintf("inform-kyverno-%s", policyName)
+	configurationPolicy := map[string]map[string]interface{}{
+		"objectDefinition": {
+			"apiVersion": configPolicyAPIVersion,
+			"kind":       configPolicyKind,
+			"metadata":   map[string]interface{}{"name": configPolicyName},
+			"spec": map[string]interface{}{
+				"namespaceSelector": map[string]interface{}{
+					"exclude": []string{"kube-*"},
+					"include": []string{"*"},
+				},
+				"remediationAction": "inform",
+				"severity":          severity,
+				"object-templates": []map[string]interface{}{
+					{
+						"complianceType": "mustnothave",
+						"objectDefinition": map[string]interface{}{
+							"apiVersion": kyvernoPolicyReportAPIVersion,
+							"kind":       kyvernoClusterKind + "Report",
+							"results": []map[string]interface{}{
+								{
+									"policy": policyName,
+									"result": "fail",
+								},
+							},
+						},
+					},
+					{
+						"complianceType": "mustnothave",
+						"objectDefinition": map[string]interface{}{
+							"apiVersion": kyvernoPolicyReportAPIVersion,
+							"kind":       kyvernoNamespacedKind + "Report",
+							"results": []map[string]interface{}{
+								{
+									"policy": policyName,
+									"result": "fail",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	templates = append(templates, configurationPolicy)
+
+	return templates
+}

--- a/internal/expanders/test_kyverno.go
+++ b/internal/expanders/test_kyverno.go
@@ -1,0 +1,158 @@
+// Copyright Contributors to the Open Cluster Management project
+package expanders
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/open-cluster-management/policy-generator-plugin/internal/types"
+)
+
+func assertEqual(t *testing.T, a interface{}, b interface{}) {
+	t.Helper()
+	if a != b {
+		t.Fatalf("%s != %s", a, b)
+	}
+}
+
+func assertReflectEqual(t *testing.T, a interface{}, b interface{}) {
+	t.Helper()
+	if !reflect.DeepEqual(a, b) {
+		t.Fatalf("%s != %s", a, b)
+	}
+}
+
+func TestCanHandle(t *testing.T) {
+	t.Parallel()
+	k := KyvernoPolicyExpander{}
+
+	tests := []struct{ kind string }{
+		{kyvernoClusterKind},
+		{kyvernoNamespacedKind},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(
+			fmt.Sprintf("kind=%s", test.kind),
+			func(t *testing.T) {
+				t.Parallel()
+				manifest := map[string]interface{}{
+					"apiVersion": kyvernoAPIVersion,
+					"kind":       test.kind,
+					"metadata": map[string]string{
+						"name": "my-awesome-policy",
+					},
+				}
+				assertEqual(t, k.CanHandle(manifest), true)
+			},
+		)
+	}
+}
+
+func TestCanHandleInvalid(t *testing.T) {
+	t.Parallel()
+	k := KyvernoPolicyExpander{}
+
+	tests := []struct{ apiVersion, kind, name string }{
+		{"v1", kyvernoClusterKind, "my-awesome-policy"},
+		{"v1", kyvernoNamespacedKind, "my-awesome-policy"},
+		{kyvernoAPIVersion, "ConfigMap", "my-awesome-policy"},
+		{kyvernoAPIVersion, kyvernoClusterKind, ""},
+		{kyvernoAPIVersion, kyvernoNamespacedKind, ""},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(
+			fmt.Sprintf("kind=%s", test.kind),
+			func(t *testing.T) {
+				t.Parallel()
+				manifest := map[string]interface{}{
+					"apiVersion": test.apiVersion,
+					"kind":       test.kind,
+					"metadata": map[string]string{
+						"name": test.name,
+					},
+				}
+				assertEqual(t, k.CanHandle(manifest), false)
+			},
+		)
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	t.Parallel()
+	k := KyvernoPolicyExpander{}
+	tests := []struct {
+		Enabled  bool
+		Expected bool
+	}{{true, true}, {false, false}}
+	for _, test := range tests {
+		policyConf := types.PolicyConfig{InformKyvernoPolicies: test.Enabled}
+		assertEqual(t, k.Enabled(&policyConf), test.Expected)
+	}
+}
+
+func TestExpand(t *testing.T) {
+	t.Parallel()
+	k := KyvernoPolicyExpander{}
+	manifest := map[string]interface{}{
+		"apiVersion": kyvernoAPIVersion,
+		"kind":       kyvernoClusterKind,
+		"metadata": map[string]string{
+			"name": "my-awesome-policy",
+		},
+	}
+
+	expected := []map[string]map[string]interface{}{
+		{
+			"objectDefinition": {
+				"apiVersion": configPolicyAPIVersion,
+				"kind":       configPolicyKind,
+				"metadata":   map[string]interface{}{"name": "inform-kyverno-my-awesome-policy"},
+				"spec": map[string]interface{}{
+					"namespaceSelector": map[string]interface{}{
+						"exclude": []string{"kube-*"},
+						"include": []string{"*"},
+					},
+					"remediationAction": "inform",
+					"severity":          "medium",
+					"object-templates": []map[string]interface{}{
+						{
+							"complianceType": "mustnothave",
+							"objectDefinition": map[string]interface{}{
+								"apiVersion": kyvernoPolicyReportAPIVersion,
+								"kind":       "ClusterPolicyReport",
+								"results": []map[string]interface{}{
+									{
+										"policy": "my-awesome-policy",
+										"result": "fail",
+									},
+								},
+							},
+						},
+						{
+							"complianceType": "mustnothave",
+							"objectDefinition": map[string]interface{}{
+								"apiVersion": kyvernoPolicyReportAPIVersion,
+								"kind":       "PolicyReport",
+								"results": []map[string]interface{}{
+									{
+										"policy": "my-awesome-policy",
+										"result": "fail",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	templates := k.Expand(manifest, "medium")
+
+	assertReflectEqual(t, templates, expected)
+}

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -306,9 +306,8 @@ func (p *Plugin) createPolicy(policyConf *types.PolicyConfig) error {
 			"namespace": p.PolicyDefaults.Namespace,
 		},
 		"spec": map[string]interface{}{
-			"disabled":          policyConf.Disabled,
-			"policy-templates":  []map[string]map[string]interface{}{*policyTemplate},
-			"remediationAction": policyConf.RemediationAction,
+			"disabled":         policyConf.Disabled,
+			"policy-templates": []map[string]map[string]interface{}{*policyTemplate},
 		},
 	}
 

--- a/internal/plugin_config_test.go
+++ b/internal/plugin_config_test.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"path"
 	"testing"
+
+	"github.com/open-cluster-management/policy-generator-plugin/internal/types"
 )
 
 func createConfigMap(t *testing.T, tmpDir, filename string) {
@@ -87,7 +89,7 @@ policies:
 	assertEqual(t, p.PolicyDefaults.ComplianceType, "musthave")
 	assertReflectEqual(t, p.PolicyDefaults.Controls, []string{"PR.DS-1 Data-at-rest"})
 	assertEqual(t, p.PolicyDefaults.Namespace, "my-policies")
-	expectedNsSelector := namespaceSelector{
+	expectedNsSelector := types.NamespaceSelector{
 		Exclude: []string{"my-protected-ns"}, Include: []string{"default"},
 	}
 	assertReflectEqual(t, p.PolicyDefaults.NamespaceSelector, expectedNsSelector)
@@ -110,7 +112,7 @@ policies:
 	assertEqual(t, len(policy1.Manifests), 1)
 	assertEqual(t, policy1.Manifests[0].Path, configMapPath)
 	assertEqual(t, policy1.Name, "policy-app-config")
-	p1ExpectedNsSelector := namespaceSelector{
+	p1ExpectedNsSelector := types.NamespaceSelector{
 		Exclude: nil, Include: []string{"app-ns"},
 	}
 	assertReflectEqual(t, policy1.NamespaceSelector, p1ExpectedNsSelector)
@@ -174,7 +176,7 @@ policies:
 	assertEqual(t, p.PolicyDefaults.ComplianceType, "musthave")
 	assertReflectEqual(t, p.PolicyDefaults.Controls, []string{"CM-2 Baseline Configuration"})
 	assertEqual(t, p.PolicyDefaults.Namespace, "my-policies")
-	expectedNsSelector := namespaceSelector{Exclude: nil, Include: nil}
+	expectedNsSelector := types.NamespaceSelector{Exclude: nil, Include: nil}
 	assertReflectEqual(t, p.PolicyDefaults.NamespaceSelector, expectedNsSelector)
 	assertEqual(t, p.PolicyDefaults.Placement.PlacementRulePath, "")
 	assertEqual(t, len(p.PolicyDefaults.Placement.ClusterSelectors), 0)

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -80,7 +80,6 @@ spec:
                             name: my-configmap
                 remediationAction: inform
                 severity: low
-    remediationAction: inform
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
@@ -111,7 +110,6 @@ spec:
                             name: my-configmap
                 remediationAction: inform
                 severity: low
-    remediationAction: inform
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
@@ -206,7 +204,6 @@ spec:
                             name: my-configmap
                 remediationAction: inform
                 severity: low
-    remediationAction: inform
 ---
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
@@ -237,7 +234,6 @@ spec:
                             name: my-configmap
                 remediationAction: inform
                 severity: low
-    remediationAction: inform
 ---
 apiVersion: apps.open-cluster-management.io/v1
 kind: PlacementRule
@@ -391,7 +387,6 @@ spec:
                             name: my-configmap
                 remediationAction: inform
                 severity: low
-    remediationAction: inform
 `
 	expected = strings.TrimPrefix(expected, "\n")
 	assertEqual(t, output, expected)
@@ -460,7 +455,6 @@ spec:
                             name: my-configmap
                 remediationAction: inform
                 severity: low
-    remediationAction: inform
 `
 	expected = strings.TrimPrefix(expected, "\n")
 	assertEqual(t, output, expected)

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -42,7 +42,7 @@ func TestGenerate(t *testing.T) {
 		},
 	}
 	p.Policies = append(p.Policies, policyConf, policyConf2)
-	p.applyDefaults()
+	p.applyDefaults(map[string]interface{}{})
 	if err := p.assertValidConfig(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -168,7 +168,7 @@ func TestGenerateSeparateBindings(t *testing.T) {
 		},
 	}
 	p.Policies = append(p.Policies, policyConf, policyConf2)
-	p.applyDefaults()
+	p.applyDefaults(map[string]interface{}{})
 	if err := p.assertValidConfig(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -317,7 +317,7 @@ func TestGenerateMissingBindingName(t *testing.T) {
 		},
 	}
 	p.Policies = append(p.Policies, policyConf, policyConf2)
-	p.applyDefaults()
+	p.applyDefaults(map[string]interface{}{})
 	if err := p.assertValidConfig(); err != nil {
 		t.Fatal(err.Error())
 	}
@@ -348,7 +348,7 @@ func TestCreatePolicy(t *testing.T) {
 		},
 	}
 	p.Policies = append(p.Policies, policyConf)
-	p.applyDefaults()
+	p.applyDefaults(map[string]interface{}{})
 
 	err := p.createPolicy(&p.Policies[0])
 	if err != nil {
@@ -405,7 +405,7 @@ func TestCreatePolicyDir(t *testing.T) {
 		NamespaceSelector: types.NamespaceSelector{Include: []string{"default"}},
 	}
 	p.Policies = append(p.Policies, policyConf)
-	p.applyDefaults()
+	p.applyDefaults(map[string]interface{}{})
 
 	err := p.createPolicy(&p.Policies[0])
 	if err != nil {
@@ -475,7 +475,7 @@ func TestCreatePolicyInvalidYAML(t *testing.T) {
 		Manifests: []types.Manifest{{Path: manifestPath}},
 	}
 	p.Policies = append(p.Policies, policyConf)
-	p.applyDefaults()
+	p.applyDefaults(map[string]interface{}{})
 
 	err = p.createPolicy(&p.Policies[0])
 	if err == nil {

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/open-cluster-management/policy-generator-plugin/internal/types"
 )
 
 func TestGenerate(t *testing.T) {
@@ -24,18 +26,18 @@ func TestGenerate(t *testing.T) {
 			},
 		},
 	}
-	policyConf := policyConfig{
+	policyConf := types.PolicyConfig{
 		Name: "policy-app-config",
-		Manifests: []manifest{
+		Manifests: []types.Manifest{
 			{
 				Path:    path.Join(tmpDir, "configmap.yaml"),
 				Patches: []map[string]interface{}{patch},
 			},
 		},
 	}
-	policyConf2 := policyConfig{
+	policyConf2 := types.PolicyConfig{
 		Name: "policy-app-config2",
-		Manifests: []manifest{
+		Manifests: []types.Manifest{
 			{Path: path.Join(tmpDir, "configmap.yaml")},
 		},
 	}
@@ -155,15 +157,15 @@ func TestGenerateSeparateBindings(t *testing.T) {
 	createConfigMap(t, tmpDir, "configmap.yaml")
 	p := Plugin{}
 	p.PolicyDefaults.Namespace = "my-policies"
-	policyConf := policyConfig{
+	policyConf := types.PolicyConfig{
 		Name: "policy-app-config",
-		Manifests: []manifest{
+		Manifests: []types.Manifest{
 			{Path: path.Join(tmpDir, "configmap.yaml")},
 		},
 	}
-	policyConf2 := policyConfig{
+	policyConf2 := types.PolicyConfig{
 		Name: "policy-app-config2",
-		Manifests: []manifest{
+		Manifests: []types.Manifest{
 			{Path: path.Join(tmpDir, "configmap.yaml")},
 		},
 	}
@@ -306,15 +308,15 @@ func TestGenerateMissingBindingName(t *testing.T) {
 	p.PlacementBindingDefaults.Name = ""
 	p.PolicyDefaults.Placement.Name = "my-placement-rule"
 	p.PolicyDefaults.Namespace = "my-policies"
-	policyConf := policyConfig{
+	policyConf := types.PolicyConfig{
 		Name: "policy-app-config",
-		Manifests: []manifest{
+		Manifests: []types.Manifest{
 			{Path: path.Join(tmpDir, "configmap.yaml")},
 		},
 	}
-	policyConf2 := policyConfig{
+	policyConf2 := types.PolicyConfig{
 		Name: "policy-app-config2",
-		Manifests: []manifest{
+		Manifests: []types.Manifest{
 			{Path: path.Join(tmpDir, "configmap.yaml")},
 		},
 	}
@@ -343,9 +345,9 @@ func TestCreatePolicy(t *testing.T) {
 	createConfigMap(t, tmpDir, "configmap.yaml")
 	p := Plugin{}
 	p.PolicyDefaults.Namespace = "my-policies"
-	policyConf := policyConfig{
+	policyConf := types.PolicyConfig{
 		Name: "policy-app-config",
-		Manifests: []manifest{
+		Manifests: []types.Manifest{
 			{Path: path.Join(tmpDir, "configmap.yaml")},
 		},
 	}
@@ -402,10 +404,10 @@ func TestCreatePolicyDir(t *testing.T) {
 	createConfigMap(t, tmpDir, "configmap2.yaml")
 	p := Plugin{}
 	p.PolicyDefaults.Namespace = "my-policies"
-	policyConf := policyConfig{
+	policyConf := types.PolicyConfig{
 		Name:              "policy-app-config",
-		Manifests:         []manifest{{Path: tmpDir}},
-		NamespaceSelector: namespaceSelector{Include: []string{"default"}},
+		Manifests:         []types.Manifest{{Path: tmpDir}},
+		NamespaceSelector: types.NamespaceSelector{Include: []string{"default"}},
 	}
 	p.Policies = append(p.Policies, policyConf)
 	p.applyDefaults()
@@ -474,9 +476,9 @@ func TestCreatePolicyInvalidYAML(t *testing.T) {
 	}
 	p := Plugin{}
 	p.PolicyDefaults.Namespace = "my-policies"
-	policyConf := policyConfig{
+	policyConf := types.PolicyConfig{
 		Name:      "policy-app-config",
-		Manifests: []manifest{{Path: manifestPath}},
+		Manifests: []types.Manifest{{Path: manifestPath}},
 	}
 	p.Policies = append(p.Policies, policyConf)
 	p.applyDefaults()
@@ -499,7 +501,7 @@ func TestCreatePlacementRuleDefault(t *testing.T) {
 	p.allPlrs = map[string]bool{}
 	p.csToPlr = map[string]string{}
 	p.PolicyDefaults.Namespace = "my-policies"
-	policyConf := policyConfig{Name: "policy-app-config"}
+	policyConf := types.PolicyConfig{Name: "policy-app-config"}
 
 	name, err := p.createPlacementRule(&policyConf)
 	if err != nil {
@@ -533,7 +535,7 @@ func TestCreatePlacementRuleSinglePlr(t *testing.T) {
 	p.csToPlr = map[string]string{}
 	p.PolicyDefaults.Namespace = "my-policies"
 	p.PolicyDefaults.Placement.Name = "my-placement-rule"
-	policyConf := policyConfig{Name: "policy-app-config"}
+	policyConf := types.PolicyConfig{Name: "policy-app-config"}
 
 	name, err := p.createPlacementRule(&policyConf)
 	if err != nil {
@@ -573,7 +575,7 @@ func TestCreatePlacementRuleClusterSelectors(t *testing.T) {
 	p.allPlrs = map[string]bool{}
 	p.csToPlr = map[string]string{}
 	p.PolicyDefaults.Namespace = "my-policies"
-	policyConf := policyConfig{Name: "policy-app-config"}
+	policyConf := types.PolicyConfig{Name: "policy-app-config"}
 	policyConf.Placement.ClusterSelectors = map[string]string{
 		"cloud": "red hat",
 		"game":  "pacman",
@@ -618,15 +620,15 @@ func TestCreatePlacementRuleDuplicateName(t *testing.T) {
 	p.allPlrs = map[string]bool{}
 	p.csToPlr = map[string]string{}
 	p.PolicyDefaults.Namespace = "my-policies"
-	policyConf := policyConfig{
+	policyConf := types.PolicyConfig{
 		Name: "policy-app-config",
-		Placement: placementConfig{
+		Placement: types.PlacementConfig{
 			Name: "my-placement",
 		},
 	}
-	policyConf2 := policyConfig{
+	policyConf2 := types.PolicyConfig{
 		Name: "policy-app-config2",
-		Placement: placementConfig{
+		Placement: types.PlacementConfig{
 			ClusterSelectors: map[string]string{"my": "app"},
 			Name:             "my-placement",
 		},
@@ -659,7 +661,7 @@ func plrPathHelper(t *testing.T, plrYAML string) (*Plugin, string) {
 	p.allPlrs = map[string]bool{}
 	p.processedPlrs = map[string]bool{}
 	p.PolicyDefaults.Namespace = "my-policies"
-	policyConf := policyConfig{Name: "policy-app-config"}
+	policyConf := types.PolicyConfig{Name: "policy-app-config"}
 	policyConf.Placement.PlacementRulePath = plrPath
 	p.Policies = append(p.Policies, policyConf)
 
@@ -832,14 +834,14 @@ func TestCreatePlacementBinding(t *testing.T) {
 	t.Parallel()
 	p := Plugin{}
 	p.PolicyDefaults.Namespace = "my-policies"
-	policyConf := policyConfig{Name: "policy-app-config"}
+	policyConf := types.PolicyConfig{Name: "policy-app-config"}
 	p.Policies = append(p.Policies, policyConf)
-	policyConf2 := policyConfig{Name: "policy-app-config2"}
+	policyConf2 := types.PolicyConfig{Name: "policy-app-config2"}
 	p.Policies = append(p.Policies, policyConf2)
 
 	bindingName := "my-placement-binding"
 	plrName := "my-placement-rule"
-	policyConfs := []*policyConfig{}
+	policyConfs := []*types.PolicyConfig{}
 	policyConfs = append(policyConfs, &p.Policies[0], &p.Policies[1])
 
 	err := p.createPlacementBinding(bindingName, plrName, policyConfs)

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,0 +1,50 @@
+// Copyright Contributors to the Open Cluster Management project
+package types
+
+type Manifest struct {
+	Patches []map[string]interface{} `json:"patches,omitempty" yaml:"patches,omitempty"`
+	Path    string                   `json:"path,omitempty" yaml:"path,omitempty"`
+}
+
+type NamespaceSelector struct {
+	Exclude []string `json:"exclude,omitempty" yaml:"exclude,omitempty"`
+	Include []string `json:"include,omitempty" yaml:"include,omitempty"`
+}
+
+type PlacementConfig struct {
+	ClusterSelectors  map[string]string `json:"clusterSelectors,omitempty" yaml:"clusterSelectors,omitempty"`
+	Name              string            `json:"name,omitempty" yaml:"name,omitempty"`
+	PlacementRulePath string            `json:"placementRulePath,omitempty" yaml:"placementRulePath,omitempty"`
+}
+
+// PolicyConfig represents a policy entry in the PolicyGenerator configuration.
+type PolicyConfig struct {
+	Categories     []string `json:"categories,omitempty" yaml:"categories,omitempty"`
+	ComplianceType string   `json:"complianceType,omitempty" yaml:"complianceType,omitempty"`
+	Controls       []string `json:"controls,omitempty" yaml:"controls,omitempty"`
+	Disabled       bool     `json:"disabled,omitempty" yaml:"disabled,omitempty"`
+	// Make this a slice of structs in the event we want additional configuration related to
+	// a manifest such as accepting patches.
+	Manifests         []Manifest        `json:"manifests,omitempty" yaml:"manifests,omitempty"`
+	Name              string            `json:"name,omitempty" yaml:"name,omitempty"`
+	NamespaceSelector NamespaceSelector `json:"namespaceSelector,omitempty" yaml:"namespaceSelector,omitempty"`
+	// This is named Placement so that eventually PlacementRules and Placements will be supported
+	Placement         PlacementConfig `json:"placement,omitempty" yaml:"placement,omitempty"`
+	RemediationAction string          `json:"remediationAction,omitempty" yaml:"remediationAction,omitempty"`
+	Severity          string          `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Standards         []string        `json:"standards,omitempty" yaml:"standards,omitempty"`
+}
+
+type PolicyDefaults struct {
+	Categories            []string          `json:"categories,omitempty" yaml:"categories,omitempty"`
+	ComplianceType        string            `json:"complianceType,omitempty" yaml:"complianceType,omitempty"`
+	Controls              []string          `json:"controls,omitempty" yaml:"controls,omitempty"`
+	InformKyvernoPolicies bool              `json:"informKyvernoPolicies,omitempty" yaml:"informKyvernoPolicies,omitempty"`
+	Namespace             string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	NamespaceSelector     NamespaceSelector `json:"namespaceSelector,omitempty" yaml:"namespaceSelector,omitempty"`
+	// This is named Placement so that eventually PlacementRules and Placements will be supported
+	Placement         PlacementConfig `json:"placement,omitempty" yaml:"placement,omitempty"`
+	RemediationAction string          `json:"remediationAction,omitempty" yaml:"remediationAction,omitempty"`
+	Severity          string          `json:"severity,omitempty" yaml:"severity,omitempty"`
+	Standards         []string        `json:"standards,omitempty" yaml:"standards,omitempty"`
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -19,10 +19,11 @@ type PlacementConfig struct {
 
 // PolicyConfig represents a policy entry in the PolicyGenerator configuration.
 type PolicyConfig struct {
-	Categories     []string `json:"categories,omitempty" yaml:"categories,omitempty"`
-	ComplianceType string   `json:"complianceType,omitempty" yaml:"complianceType,omitempty"`
-	Controls       []string `json:"controls,omitempty" yaml:"controls,omitempty"`
-	Disabled       bool     `json:"disabled,omitempty" yaml:"disabled,omitempty"`
+	Categories            []string `json:"categories,omitempty" yaml:"categories,omitempty"`
+	ComplianceType        string   `json:"complianceType,omitempty" yaml:"complianceType,omitempty"`
+	Controls              []string `json:"controls,omitempty" yaml:"controls,omitempty"`
+	Disabled              bool     `json:"disabled,omitempty" yaml:"disabled,omitempty"`
+	InformKyvernoPolicies bool     `json:"informKyvernoPolicies,omitempty" yaml:"informKyvernoPolicies,omitempty"`
 	// Make this a slice of structs in the event we want additional configuration related to
 	// a manifest such as accepting patches.
 	Manifests         []Manifest        `json:"manifests,omitempty" yaml:"manifests,omitempty"`

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -10,12 +10,13 @@ import (
 	"os"
 	"path"
 
+	"github.com/open-cluster-management/policy-generator-plugin/internal/types"
 	"gopkg.in/yaml.v3"
 )
 
 // getManifests will get all of the manifest files associated with the input policy configuration.
 // An error is returned if a manifest path cannot be read.
-func getManifests(policyConf *policyConfig) (*[]map[string]interface{}, error) {
+func getManifests(policyConf *types.PolicyConfig) (*[]map[string]interface{}, error) {
 	manifests := []map[string]interface{}{}
 	for _, manifest := range policyConf.Manifests {
 		manifestPaths := []string{}
@@ -87,7 +88,7 @@ func getManifests(policyConf *policyConfig) (*[]map[string]interface{}, error) {
 // getPolicyTemplate generates a policy template for a ConfigurationPolicy
 // that includes the manifests specified in policyConf. An error is returned
 // if one or more manifests cannot be read or are invalid.
-func getPolicyTemplate(policyConf *policyConfig) (
+func getPolicyTemplate(policyConf *types.PolicyConfig) (
 	*map[string]map[string]interface{}, error,
 ) {
 	manifests, err := getManifests(policyConf)

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/open-cluster-management/policy-generator-plugin/internal/types"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -28,7 +29,7 @@ func assertReflectEqual(t *testing.T, a interface{}, b interface{}) {
 func TestGetPolicyTemplate(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	manifestFiles := []manifest{}
+	manifestFiles := []types.Manifest{}
 	for i, enemy := range []string{"goldfish", "potato"} {
 		manifestPath := path.Join(tmpDir, fmt.Sprintf("configmap%d.yaml", i))
 		manifestYAML := fmt.Sprintf(
@@ -47,7 +48,7 @@ data:
 			t.Fatalf("Failed to write %s", manifestPath)
 		}
 
-		manifestFiles = append(manifestFiles, manifest{Path: manifestPath})
+		manifestFiles = append(manifestFiles, types.Manifest{Path: manifestPath})
 	}
 
 	// Write a bogus file to ensure it is not picked up when creating the policy
@@ -59,12 +60,12 @@ data:
 	}
 
 	// Test both passing in individual files and a flat directory
-	tests := []struct{ Manifests []manifest }{
+	tests := []struct{ Manifests []types.Manifest }{
 		{Manifests: manifestFiles},
-		{Manifests: []manifest{{Path: tmpDir}}},
+		{Manifests: []types.Manifest{{Path: tmpDir}}},
 	}
 	for _, test := range tests {
-		policyConf := policyConfig{
+		policyConf := types.PolicyConfig{
 			ComplianceType:    "musthave",
 			Manifests:         test.Manifests,
 			Name:              "policy-app-config",
@@ -133,10 +134,10 @@ data:
 			},
 		},
 	}
-	manifests := []manifest{
+	manifests := []types.Manifest{
 		{Path: manifestPath, Patches: patches},
 	}
-	policyConf := policyConfig{
+	policyConf := types.PolicyConfig{
 		Manifests: manifests,
 		Name:      "policy-app-config",
 	}
@@ -184,9 +185,9 @@ data:
 func TestGetPolicyTemplateNoManifests(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	policyConf := policyConfig{
+	policyConf := types.PolicyConfig{
 		ComplianceType:    "musthave",
-		Manifests:         []manifest{{Path: tmpDir}},
+		Manifests:         []types.Manifest{{Path: tmpDir}},
 		Name:              "policy-app-config",
 		RemediationAction: "inform",
 		Severity:          "low",
@@ -205,9 +206,9 @@ func TestGetPolicyTemplateInvalidPath(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	manifestPath := path.Join(tmpDir, "does-not-exist.yaml")
-	policyConf := policyConfig{
+	policyConf := types.PolicyConfig{
 		ComplianceType:    "musthave",
-		Manifests:         []manifest{{Path: manifestPath}},
+		Manifests:         []types.Manifest{{Path: manifestPath}},
 		Name:              "policy-app-config",
 		RemediationAction: "inform",
 		Severity:          "low",
@@ -232,9 +233,9 @@ func TestGetPolicyTemplateInvalidManifest(t *testing.T) {
 		t.Fatalf("Failed to write %s", manifestPath)
 	}
 
-	policyConf := policyConfig{
+	policyConf := types.PolicyConfig{
 		ComplianceType:    "musthave",
-		Manifests:         []manifest{{Path: manifestPath}},
+		Manifests:         []types.Manifest{{Path: manifestPath}},
 		Name:              "policy-app-config",
 		RemediationAction: "inform",
 		Severity:          "low",


### PR DESCRIPTION
By default, when a manifest includes a Kyverno policy, an additional
configuration policy will get generated to inform on Kyverno policy
violations in Open Cluster Management.

Additionally, remediation action is no longer set at the root policy level.
This allows the policy generator to have granular control of the
remediation action of configuration policies it may automatically
generator on behalf of the user (i.e. Kyverno policy reporting).