### PR TITLE
Build the release binaries statically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.dylib
 **/.DS_Store
 PolicyGenerator
+build_output
 
 # Test binary, built with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,9 @@ build-release:
 			exit 1; \
 	fi
 	@mkdir -p build_output
-	GOOS=linux GOARCH=amd64 go build -o build_output/linux-amd64-PolicyGenerator cmd/main.go
-	GOOS=darwin GOARCH=amd64 go build -o build_output/darwin-amd64-PolicyGenerator cmd/main.go
-	GOOS=windows GOARCH=amd64 go build -o build_output/windows-amd64-PolicyGenerator.exe cmd/main.go
+	GOOS=linux CGO_ENABLED=0 GOARCH=amd64 go build -o build_output/linux-amd64-PolicyGenerator cmd/main.go
+	GOOS=darwin CGO_ENABLED=0 GOARCH=amd64 go build -o build_output/darwin-amd64-PolicyGenerator cmd/main.go
+	GOOS=windows CGO_ENABLED=0 GOARCH=amd64 go build -o build_output/windows-amd64-PolicyGenerator.exe cmd/main.go
 
 generate:
 	@KUSTOMIZE_PLUGIN_HOME=$(KUSTOMIZE_PLUGIN_HOME) kustomize build --enable-alpha-plugins $(SOURCE_DIR)


### PR DESCRIPTION
This resolves the issue on some systems that get the error:
PolicyGenerator: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by PolicyGenerator)

Signed-off-by: mprahl <mprahl@users.noreply.github.com>