### PR TITLE
Implement the Placement API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 ## Overview
 
-The Policy Generator constructs Open Cluster Management policies from Kubernetes YAML files provided through a PolicyGenerator Custom Resource. The Policy Generator is a binary compiled for use as a [kustomize](https://kustomize.io/) exec plugin.
+The Policy Generator constructs Open Cluster Management policies from Kubernetes YAML files provided
+through a PolicyGenerator Custom Resource. The Policy Generator is a binary compiled for use as a
+[kustomize](https://kustomize.io/) exec plugin.
 
 For more about Open Cluster Management and its Policy Framework:
-- [Open Cluster Management website](open-cluster-management.io/)
+
+- [Open Cluster Management website](https://open-cluster-management.io/)
 - [Governance Policy Framework](https://open-cluster-management.io/getting-started/integration/policy-framework/)
 - [Policy Collection repository](https://github.com/open-cluster-management/policy-collection)
 
@@ -23,70 +26,78 @@ For more about Open Cluster Management and its Policy Framework:
 
 2. Create the plugin directory:
 
-    ```bash
-    mkdir -p ${HOME}/.config/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator
-    ```
+   ```bash
+   mkdir -p ${HOME}/.config/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator
+   ```
 
 3. Move the binary to the plugin directory:
 
-    - Linux:
+   - Linux:
 
-        ```bash
-        chmod +x linux-amd64-PolicyGenerator
-        mv linux-amd64-PolicyGenerator ${HOME}/.config/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator
-        ```
+     ```bash
+     chmod +x linux-amd64-PolicyGenerator
+     mv linux-amd64-PolicyGenerator ${HOME}/.config/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator
+     ```
 
-    - MacOS:
+   - MacOS:
 
-        ```bash
-        chmod +x darwin-amd64-PolicyGenerator
-        mv darwin-amd64-PolicyGenerator ${HOME}/.config/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator
-        ```
+     ```bash
+     chmod +x darwin-amd64-PolicyGenerator
+     mv darwin-amd64-PolicyGenerator ${HOME}/.config/kustomize/plugin/policy.open-cluster-management.io/v1/policygenerator/PolicyGenerator
+     ```
 
 ##### Build and install from source
 
 1. Build the plugin binary (only needed once or to update the plugin):
-    ```bash
-    make build
-    ```
-    **NOTE:** This will default to placing the binary in `${HOME}/.config/kustomize/plugin/`. You can change this by exporting `KUSTOMIZE_PLUGIN_HOME` to a different path.
+   ```bash
+   make build
+   ```
+   **NOTE:** This will default to placing the binary in `${HOME}/.config/kustomize/plugin/`. You can
+   change this by exporting `KUSTOMIZE_PLUGIN_HOME` to a different path.
 
 #### Configuration
 
-1. Create a `kustomization.yaml` file that points to `PolicyGenerator` manifest(s), with any additional desired patches or customizations (see [`examples/policyGenerator.yaml`](./examples/policyGenerator.yaml) for an example):
-    ```yaml
-    generators:
-    - path/to/generator/file.yaml
-    ...
-    ```
-    - To read more about the `PolicyGenerator` YAML, see [About the PolicyGenerator plugin](./docs/policygenerator.md)
+1. Create a `kustomization.yaml` file that points to `PolicyGenerator` manifest(s), with any
+   additional desired patches or customizations (see
+   [`examples/policyGenerator.yaml`](./examples/policyGenerator.yaml) for an example):
+
+   ```yaml
+   generators:
+     - path/to/generator/file.yaml
+   ```
+
+   - To read more about the `PolicyGenerator` YAML, see
+     [About the PolicyGenerator plugin](./docs/policygenerator.md)
 
 2. To use the plugin to generate policies, do one of:
-    - Utilize the `examples/` directory in this repository (the directory can be modified by exporting a new path to `SOURCE_DIR`):
-      ```bash
-      make generate
-      ```
-    - From any directory with a `kustomization.yaml` file pointing to `PolicyGenerator` manifests:
-      ```bash
-      kustomize build --enable-alpha-plugins
-      ```
+   - Utilize the `examples/` directory in this repository (the directory can be modified by
+     exporting a new path to `SOURCE_DIR`):
+     ```bash
+     make generate
+     ```
+   - From any directory with a `kustomization.yaml` file pointing to `PolicyGenerator` manifests:
+     ```bash
+     kustomize build --enable-alpha-plugins
+     ```
 
 ### As a standalone binary
 
 In order to bypass Kustomize and run the generator binary directly:
 
 1. Build the binary:
-    ```bash
-    make build-binary
-    ```
+
+   ```bash
+   make build-binary
+   ```
 
 2. Run the binary from the location of the PolicyGenerator manifest(s):
-    ```bash
-    path/to/PolicyGenerator <path/to/file/1> ... <path/to/file/n>
-    ```
-    - For example:
-      ```bash
-      cd examples
-      ../PolicyGenerator policyGenerator.yaml
-      ```
-    **NOTE:** To print the trace in the case of an error, you can add the `--debug` flag to the arguments.
+   ```bash
+   path/to/PolicyGenerator <path/to/file/1> ... <path/to/file/n>
+   ```
+   - For example:
+     ```bash
+     cd examples
+     ../PolicyGenerator policyGenerator.yaml
+     ```
+     **NOTE:** To print the trace in the case of an error, you can add the `--debug` flag to the
+     arguments.

--- a/docs/policygenerator-reference.yaml
+++ b/docs/policygenerator-reference.yaml
@@ -35,15 +35,22 @@ policyDefaults:
   # Optional. The placement configuration for the policies. This defaults to a placement
   # configuration that matches all clusters.
   placement:
-    # To specify a placement, specify key:value pair cluster selectors. (See placementRulePath to
-    # specify an existing file instead.)
+    # To specify a placement rule, specify key:value pair cluster selectors. (See placementRulePath
+    # to specify an existing file instead.)
     clusterSelectors: {}
+    # To specify a placement, specify key:value pair cluster label selectors. (See placementPath to
+    # specify an existing file instead.)
+    labelSelector: {}
     # Optional. Specifying a name will consolidate placement rules that contain the same cluster
     # selectors.
     name: ""
-    # To reuse an existing placement rule, specify the path here relative to the kustomization.yaml
-    # file. If given, this placement rule will be used by all policies by default. (See
-    # clusterSelectors to generate a new Placement instead.)
+    # To reuse an existing placement manifest, specify the path here relative to the
+    # kustomization.yaml file. If given, this placement will be used by all policies by default.
+    # (See clusterSelectors to generate a new Placement instead.)
+    placementPath: ""
+    # To reuse an existing placement rule manifest, specify the path here relative to the
+    # kustomization.yaml file. If given, this placement rule will be used by all policies by
+    # default. (See clusterSelectors to generate a new PlacementRule instead.)
     placementRulePath: ""
   # Optional. The remediation action ("inform" or "enforce") for each configuration policy. This
   # defaults to "inform".
@@ -58,12 +65,12 @@ policyDefaults:
 # Required. The list of policies to create along with overrides to either the default values or, if
 # set, the values given in policyDefaults.
 policies:
-  # Required. The name of the policy to create.
+    # Required. The name of the policy to create.
   - name: ""
     # Required. The list of Kubernetes resource object manifests to include in the policy.
     manifests:
-      # Required. Path to a single file or a flat directory of files relative to the
-      # kustomization.yaml file.
+        # Required. Path to a single file or a flat directory of files relative to the
+        # kustomization.yaml file.
       - path: ""
         # Optional. (See policy[0].complianceType for description.)
         complianceType: "musthave"

--- a/docs/policygenerator.md
+++ b/docs/policygenerator.md
@@ -18,10 +18,15 @@ generator plugin to be enabled.
 
 By default, a Placement and PlacementBinding are created for each policy with the policy name as the
 suffix. To signal that you'd like to consolidate policies that use the same Placement under a single
-PlacementBinding, either specify `placement.placementRulePath` to an existing Placement manifest or
-set `placement.name` along with `placement.clusterSelectors`. When the PlacementBinding is
-consolidated in this way, `placementBindingDefaults.name` must be specified so that the generator
-can create unique names for the bindings.
+PlacementBinding, either specify `placement.placementRulePath` to an existing Placement manifest or set
+`placement.name` along with `placement.clusterSelectors`. When the PlacementBinding is consolidated in
+this way, `placementBindingDefaults.name` must be specified so that the generator can create unique
+names for the bindings.
+
+The PlacementRule kind in the `apps.open-cluster-management.io` API group is used by default if no
+placement is given. However, you can use the Placement kind in the
+`cluster.open-cluster-management.io` API group by specifying a Placement manifest in
+`placement.placementPath` or specifying labels in `placement.labelSelector`.
 
 ## Policy expanders
 

--- a/examples/input/placement.yaml
+++ b/examples/input/placement.yaml
@@ -1,0 +1,16 @@
+apiVersion: cluster.open-cluster-management.io/v1alpha1
+kind: Placement
+metadata:
+  labels:
+    custom: myApp
+  name: placement-red-hat-cloud
+  namespace: my-policies
+spec:
+  predicates:
+    requiredClusterSelector:
+      labelSelector:
+        matchExpressions:
+          - key: cloud
+            operator: In
+            values:
+              - red hat

--- a/examples/policyGenerator.yaml
+++ b/examples/policyGenerator.yaml
@@ -6,6 +6,7 @@ placementBindingDefaults:
   name: my-placement-binding
 policyDefaults:
   # categories: []
+  # complianceType: "musthave"
   controls: 
     - PR.DS-1 Data-at-rest
   namespace: my-policies

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -79,6 +80,10 @@ func (p *Plugin) Config(config []byte, baseDirectory string) error {
 	}
 	p.applyDefaults(unmarshaledConfig)
 
+	baseDirectory, err = filepath.EvalSymlinks(baseDirectory)
+	if err != nil {
+		return fmt.Errorf("failed to evaluate symlinks for the base directory: %w", err)
+	}
 	p.baseDirectory = baseDirectory
 
 	return p.assertValidConfig()

--- a/internal/plugin.go
+++ b/internal/plugin.go
@@ -22,6 +22,8 @@ const (
 	placementBindingKind       = "PlacementBinding"
 	placementRuleAPIVersion    = "apps.open-cluster-management.io/v1"
 	placementRuleKind          = "PlacementRule"
+	placementAPIVersion        = "cluster.open-cluster-management.io/v1alpha1"
+	placementKind              = "Placement"
 	maxObjectNameLength        = 63
 )
 
@@ -36,15 +38,18 @@ type Plugin struct {
 	} `json:"placementBindingDefaults,omitempty" yaml:"placementBindingDefaults,omitempty"`
 	PolicyDefaults types.PolicyDefaults `json:"policyDefaults,omitempty" yaml:"policyDefaults,omitempty"`
 	Policies       []types.PolicyConfig `json:"policies" yaml:"policies"`
-	// A set of all placement rule names that have been processed or generated
-	allPlrs map[string]bool
-	// This is a mapping of cluster selectors formatted as the return value of getCsKey to placement
-	// rule names. This is used to find common cluster selectors that can be consolidated to a
-	// single placement rule.
-	csToPlr      map[string]string
+	// A set of all placement names that have been processed or generated
+	allPlcs map[string]bool
+	// This is a mapping of cluster/label selectors formatted as the return value of getCsKey to
+	// placement names. This is used to find common cluster/label selectors that can be consolidated
+	// to a single placement.
+	csToPlc      map[string]string
 	outputBuffer bytes.Buffer
-	// A set of processed placement rules from external placement rules (Placement.PlacementRulePath)
-	processedPlrs map[string]bool
+	// Track placement kind (we only expect to have one kind)
+	usingPlR bool
+	// A set of processed placements from external placements (either Placement.PlacementRulePath or
+	// Placement.PlacementPath)
+	processedPlcs map[string]bool
 }
 
 var defaults = types.PolicyDefaults{
@@ -75,14 +80,14 @@ func (p *Plugin) Config(config []byte) error {
 	return p.assertValidConfig()
 }
 
-// Generate generates the policies, placement rules, and placement bindings and returns them as
+// Generate generates the policies, placements, and placement bindings and returns them as
 // a single YAML file as a byte array. An error is returned if they cannot be created.
 func (p *Plugin) Generate() ([]byte, error) {
 	// Set the default empty values to the fields that track state
-	p.allPlrs = map[string]bool{}
-	p.csToPlr = map[string]string{}
+	p.allPlcs = map[string]bool{}
+	p.csToPlc = map[string]string{}
 	p.outputBuffer = bytes.Buffer{}
-	p.processedPlrs = map[string]bool{}
+	p.processedPlcs = map[string]bool{}
 
 	for i := range p.Policies {
 		err := p.createPolicy(&p.Policies[i])
@@ -91,41 +96,41 @@ func (p *Plugin) Generate() ([]byte, error) {
 		}
 	}
 
-	// Keep track of which placement rule maps to which policy. This will be used to determine
-	// how many placement bindings are required since one per placement rule is required.
-	plrNameToPolicyIdxs := map[string][]int{}
+	// Keep track of which placement maps to which policy. This will be used to determine
+	// how many placement bindings are required since one binding per placement is required.
+	plcNameToPolicyIdxs := map[string][]int{}
 	for i := range p.Policies {
-		plrName, err := p.createPlacementRule(&p.Policies[i])
+		plcName, err := p.createPlacement(&p.Policies[i])
 		if err != nil {
 			return nil, err
 		}
-		plrNameToPolicyIdxs[plrName] = append(plrNameToPolicyIdxs[plrName], i)
+		plcNameToPolicyIdxs[plcName] = append(plcNameToPolicyIdxs[plcName], i)
 	}
 
-	// Sort the keys of plrNameToPolicyIdxs so that the policy bindings are generated in a
+	// Sort the keys of plcNameToPolicyIdxs so that the policy bindings are generated in a
 	// consistent order.
-	plrNames := make([]string, len(plrNameToPolicyIdxs))
+	plcNames := make([]string, len(plcNameToPolicyIdxs))
 	i := 0
-	for k := range plrNameToPolicyIdxs {
-		plrNames[i] = k
+	for k := range plcNameToPolicyIdxs {
+		plcNames[i] = k
 		i++
 	}
-	sort.Strings(plrNames)
+	sort.Strings(plcNames)
 
 	plcBindingCount := 0
-	for _, plrName := range plrNames {
+	for _, plcName := range plcNames {
 		// Determine which policies to be included in the placement binding.
 		policyConfs := []*types.PolicyConfig{}
-		for _, i := range plrNameToPolicyIdxs[plrName] {
+		for _, i := range plcNameToPolicyIdxs[plcName] {
 			policyConfs = append(policyConfs, &p.Policies[i])
 		}
 
-		// If there is more than one policy associated with a placement rule but no default binding name
+		// If there is more than one policy associated with a placement but no default binding name
 		// specified, throw an error
 		if len(policyConfs) > 1 && p.PlacementBindingDefaults.Name == "" {
 			return nil, fmt.Errorf(
-				"placementBindingDefaults.name must be set but is empty (mutiple policies were found for the PlacementBinding to placement '%s')",
-				plrName,
+				"placementBindingDefaults.name must be set but is empty (multiple policies were found for the PlacementBinding to placement %s)",
+				plcName,
 			)
 		}
 
@@ -145,7 +150,7 @@ func (p *Plugin) Generate() ([]byte, error) {
 			}
 		}
 
-		err := p.createPlacementBinding(bindingName, plrName, policyConfs)
+		err := p.createPlacementBinding(bindingName, plcName, policyConfs)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create a placement binding: %w", err)
 		}
@@ -282,9 +287,21 @@ func (p *Plugin) applyDefaults(unmarshaledConfig map[string]interface{}) {
 			policy.ConsolidateManifests = p.PolicyDefaults.ConsolidateManifests
 		}
 
-		// If both cluster selectors and placement rule path aren't set, then use the
-		// defaults with a priority on placement rule path.
-		if len(policy.Placement.ClusterSelectors) == 0 && policy.Placement.PlacementRulePath == "" {
+		// Determine whether defaults are set for placement
+		plcDefaultSet := len(p.PolicyDefaults.Placement.LabelSelector) != 0 || p.PolicyDefaults.Placement.PlacementPath != ""
+		plrDefaultSet := len(p.PolicyDefaults.Placement.ClusterSelectors) != 0 || p.PolicyDefaults.Placement.PlacementRulePath != ""
+
+		// If both cluster label selectors and placement path aren't set, then use the defaults with a
+		// priority on placement path.
+		if len(policy.Placement.LabelSelector) == 0 && policy.Placement.PlacementPath == "" && plcDefaultSet {
+			if p.PolicyDefaults.Placement.PlacementPath != "" {
+				policy.Placement.PlacementPath = p.PolicyDefaults.Placement.PlacementPath
+			} else if len(p.PolicyDefaults.Placement.LabelSelector) > 0 {
+				policy.Placement.LabelSelector = p.PolicyDefaults.Placement.LabelSelector
+			}
+			// Else if both cluster selectors and placement rule path aren't set, then use the defaults with a
+			// priority on placement rule path.
+		} else if len(policy.Placement.ClusterSelectors) == 0 && policy.Placement.PlacementRulePath == "" && plrDefaultSet {
 			if p.PolicyDefaults.Placement.PlacementRulePath != "" {
 				policy.Placement.PlacementRulePath = p.PolicyDefaults.Placement.PlacementRulePath
 			} else if len(p.PolicyDefaults.Placement.ClusterSelectors) > 0 {
@@ -326,48 +343,94 @@ func (p *Plugin) assertValidConfig() error {
 		return errors.New("policyDefaults.namespace is empty but it must be set")
 	}
 
+	// Validate default Placement settings
+	if p.PolicyDefaults.Placement.PlacementRulePath != "" && p.PolicyDefaults.Placement.PlacementPath != "" {
+		return errors.New(
+			"policyDefaults must provide only one of placement.placementPath or placement.placementRulePath",
+		)
+	}
+	if len(p.PolicyDefaults.Placement.ClusterSelectors) > 0 && len(p.PolicyDefaults.Placement.LabelSelector) > 0 {
+		return errors.New(
+			"policyDefaults must provide only one of placement.labelSelector or placement.clusterSelectors",
+		)
+	}
+	if (len(p.PolicyDefaults.Placement.LabelSelector) != 0 || len(p.PolicyDefaults.Placement.ClusterSelectors) != 0) &&
+		(p.PolicyDefaults.Placement.PlacementRulePath != "" || p.PolicyDefaults.Placement.PlacementPath != "") {
+		return errors.New(
+			"policyDefaults may not specify a placement selector and placement path together",
+		)
+	}
+
 	if len(p.Policies) == 0 {
 		return errors.New("policies is empty but it must be set")
 	}
 
 	seen := map[string]bool{}
+	plCount := struct {
+		plc int
+		plr int
+	}{}
 	for i := range p.Policies {
 		policy := &p.Policies[i]
-		if len(policy.Placement.ClusterSelectors) != 0 && policy.Placement.PlacementRulePath != "" {
-			return errors.New(
-				"a policy may not specify placement.clusterSelectors and " +
-					"placement.placementRulePath together",
+		if policy.Name == "" {
+			return fmt.Errorf(
+				"each policy must have a name set, but did not find a name at policy array index %d", i,
 			)
 		}
 
+		if seen[policy.Name] {
+			return fmt.Errorf(
+				"each policy must have a unique name set, but found a duplicate name: %s", policy.Name,
+			)
+		}
+		seen[policy.Name] = true
+
+		if len(p.PolicyDefaults.Namespace+"."+policy.Name) > maxObjectNameLength {
+			return fmt.Errorf("the policy namespace and name cannot be more than 63 characters: %s.%s",
+				p.PolicyDefaults.Namespace, policy.Name)
+		}
+
 		if len(policy.Manifests) == 0 {
-			return errors.New("each policy must have at least one manifest")
+			return fmt.Errorf(
+				"each policy must have at least one manifest, but found none in policy %s", policy.Name,
+			)
 		}
 
 		for _, manifest := range policy.Manifests {
 			if manifest.Path == "" {
-				return errors.New("each policy manifest entry must have path set")
+				return fmt.Errorf(
+					"each policy manifest entry must have path set, but did not find a path in policy %s",
+					policy.Name,
+				)
 			}
 
 			_, err := os.Stat(manifest.Path)
 			if err != nil {
-				return fmt.Errorf("could not read the manifest path %s", manifest.Path)
+				return fmt.Errorf(
+					"could not read the manifest path %s in policy %s", manifest.Path, policy.Name,
+				)
 			}
 		}
 
-		if policy.Name == "" {
-			return errors.New("each policy must have a name set")
+		// Validate policy Placement settings
+		if policy.Placement.PlacementRulePath != "" && policy.Placement.PlacementPath != "" {
+			return fmt.Errorf(
+				"policy %s must provide only one of placementRulePath or placementPath", policy.Name,
+			)
 		}
 
-		if len(p.PolicyDefaults.Namespace+"."+policy.Name) > maxObjectNameLength {
-			return fmt.Errorf("the policy namespace and name cannot be more than 63 characters %s.%s",
-				p.PolicyDefaults.Namespace, policy.Name)
+		if len(policy.Placement.ClusterSelectors) > 0 && len(policy.Placement.LabelSelector) > 0 {
+			return fmt.Errorf(
+				"policy %s must provide only one of placement.labelSelector or placement.clusterselectors",
+				policy.Name,
+			)
 		}
-
-		if seen[policy.Name] {
-			return fmt.Errorf("each policy must have a unique name set: %s", policy.Name)
+		if (len(policy.Placement.ClusterSelectors) != 0 || len(policy.Placement.LabelSelector) != 0) &&
+			(policy.Placement.PlacementRulePath != "" || policy.Placement.PlacementPath != "") {
+			return fmt.Errorf(
+				"policy %s may not specify a placement selector and placement path together", policy.Name,
+			)
 		}
-
 		if policy.Placement.PlacementRulePath != "" {
 			_, err := os.Stat(policy.Placement.PlacementRulePath)
 			if err != nil {
@@ -377,9 +440,40 @@ func (p *Plugin) assertValidConfig() error {
 				)
 			}
 		}
+		if policy.Placement.PlacementPath != "" {
+			_, err := os.Stat(policy.Placement.PlacementPath)
+			if err != nil {
+				return fmt.Errorf(
+					"could not read the placement path %s",
+					policy.Placement.PlacementPath,
+				)
+			}
+		}
 
-		seen[policy.Name] = true
+		foundPl := false
+		if len(policy.Placement.LabelSelector) != 0 || policy.Placement.PlacementPath != "" {
+			plCount.plc++
+			foundPl = true
+		}
+		if len(policy.Placement.ClusterSelectors) != 0 || policy.Placement.PlacementRulePath != "" {
+			plCount.plr++
+			if foundPl {
+				return fmt.Errorf(
+					"policy %s may not use both Placement and PlacementRule kinds", policy.Name,
+				)
+			}
+		}
 	}
+
+	// Validate only one type of placement kind is in use
+	if plCount.plc != 0 && plCount.plr != 0 {
+		return fmt.Errorf(
+			"may not use a mix of Placement and PlacementRule for policies; found %d Placement and %d PlacementRule",
+			plCount.plc, plCount.plr,
+		)
+	}
+
+	p.usingPlR = plCount.plc == 0
 
 	return nil
 }
@@ -424,127 +518,162 @@ func (p *Plugin) createPolicy(policyConf *types.PolicyConfig) error {
 	return nil
 }
 
-// getPlrFromPath finds the placement rule manifest in the input manifest file. It will return
-// the name of the placement rule, the unmarshaled placement rule manifest, and an error. An error
-// is returned if the placement rule manifest cannot be found or is invalid.
-func (p *Plugin) getPlrFromPath(plrPath string) (string, map[string]interface{}, error) {
-	manifests, err := unmarshalManifestFile(plrPath)
+// getPlcFromPath finds the placement manifest in the input manifest file. It will return the name
+// of the placement, the unmarshaled placement manifest, and an error. An error is returned if the
+// placement manifest cannot be found or is invalid.
+func (p *Plugin) getPlcFromPath(plcPath string) (string, map[string]interface{}, error) {
+	manifests, err := unmarshalManifestFile(plcPath)
 	if err != nil {
-		return "", nil, fmt.Errorf("failed to read the placement rule: %w", err)
+		return "", nil, fmt.Errorf("failed to read the placement: %w", err)
 	}
 
 	var name string
-	var rule map[string]interface{}
+	var placement map[string]interface{}
 	for _, manifest := range *manifests {
-		if kind, _, _ := unstructured.NestedString(manifest, "kind"); kind != placementRuleKind {
+		kind, _, _ := unstructured.NestedString(manifest, "kind")
+		if kind != placementRuleKind && kind != placementKind {
 			continue
+		}
+
+		// Validate PlacementRule Kind given in manifest
+		if kind == placementRuleKind {
+			if !p.usingPlR {
+				return "", nil, fmt.Errorf(
+					"the placement %s specified a placementRule kind but expected a placement kind", plcPath,
+				)
+			}
+		}
+
+		// Validate Placement Kind given in manifest
+		if kind == placementKind {
+			if p.usingPlR {
+				return "", nil, fmt.Errorf(
+					"the placement %s specified a placement kind but expected a placementRule kind", plcPath,
+				)
+			}
 		}
 
 		var found bool
 		name, found, err = unstructured.NestedString(manifest, "metadata", "name")
 		if !found || err != nil {
-			return "", nil, fmt.Errorf("the placement %s must have a name set", plrPath)
+			return "", nil, fmt.Errorf("the placement %s must have a name set", plcPath)
 		}
 
 		var namespace string
 		namespace, found, err = unstructured.NestedString(manifest, "metadata", "namespace")
 		if !found || err != nil {
-			return "", nil, fmt.Errorf("the placement %s must have a namespace set", plrPath)
+			return "", nil, fmt.Errorf("the placement %s must have a namespace set", plcPath)
 		}
 
 		if namespace != p.PolicyDefaults.Namespace {
 			err = fmt.Errorf(
 				"the placement %s must have the same namespace as the policy (%s)",
-				plrPath,
+				plcPath,
 				p.PolicyDefaults.Namespace,
 			)
 
 			return "", nil, err
 		}
 
-		rule = manifest
+		placement = manifest
 
 		break
 	}
 
 	if name == "" {
 		err = fmt.Errorf(
-			"the placement manifest %s did not have a placement rule", plrPath,
+			"the placement manifest %s did not have a placement", plcPath,
 		)
 
 		return "", nil, err
 	}
 
-	return name, rule, nil
+	return name, placement, nil
 }
 
-// getCsKey generates the key for the policy's cluster selectors to be used in Policies.csToPlr.
+// getCsKey generates the key for the policy's cluster/label selectors to be used in
+// Policies.csToPlc.
 func getCsKey(policyConf *types.PolicyConfig) string {
 	return fmt.Sprintf("%#v", policyConf.Placement.ClusterSelectors)
 }
 
-// getPlrName will generate a placement rule name for the policy. If the placement rule has
+// getPlcName will generate a placement name for the policy. If the placement has
 // previously been generated, skip will be true.
-func (p *Plugin) getPlrName(policyConf *types.PolicyConfig) (name string, skip bool) {
+func (p *Plugin) getPlcName(policyConf *types.PolicyConfig) (name string, skip bool) {
 	if policyConf.Placement.Name != "" {
-		// If the policy explicitly specifies a placement rule name, use it
+		// If the policy explicitly specifies a placement name, use it
 		return policyConf.Placement.Name, false
 	} else if p.PolicyDefaults.Placement.Name != "" {
-		// If the policy doesn't explicitly specify a placement rule name, and there is a
-		// default placement rule name set, check if one has already been generated for these
-		// cluster selectors
+		// If the policy doesn't explicitly specify a placement name, and there is a
+		// default placement name set, check if one has already been generated for these
+		// cluster/label selectors
 		csKey := getCsKey(policyConf)
-		if _, ok := p.csToPlr[csKey]; ok {
-			// Just reuse the previously created placement rule with the same cluster selectors
-			return p.csToPlr[csKey], true
+		if _, ok := p.csToPlc[csKey]; ok {
+			// Just reuse the previously created placement with the same cluster/label selectors
+			return p.csToPlc[csKey], true
 		}
-		// If the policy doesn't explicitly specify a placement rule name, and there is a
-		// default placement rule name, use that
-		if len(p.csToPlr) == 0 {
-			// If this is the first generated placement rule, just use it as is
+		// If the policy doesn't explicitly specify a placement name, and there is a
+		// default placement name, use that
+		if len(p.csToPlc) == 0 {
+			// If this is the first generated placement, just use it as is
 			return p.PolicyDefaults.Placement.Name, false
 		}
-		// If there is already one or more generated placement rules, increment the name
-		return fmt.Sprintf("%s%d", p.PolicyDefaults.Placement.Name, len(p.csToPlr)+1), false
+		// If there is already one or more generated placements, increment the name
+		return fmt.Sprintf("%s%d", p.PolicyDefaults.Placement.Name, len(p.csToPlc)+1), false
 	}
-	// Default to a placement rule per policy
+	// Default to a placement per policy
 	return "placement-" + policyConf.Name, false
 }
 
-// createPlacementRule creates a placement rule for the input policy configuration by writing it to
-// the policy generator's output buffer. The name of the placement rule or an error is returned.
-// If the placement rule has already been generated, it will be reused and not added to the
-// policy generator's output buffer. An error is returned if the placement rule cannot be created.
-func (p *Plugin) createPlacementRule(policyConf *types.PolicyConfig) (
+// createPlacement creates a placement for the input policy configuration by writing it to
+// the policy generator's output buffer. The name of the placement or an error is returned.
+// If the placement has already been generated, it will be reused and not added to the
+// policy generator's output buffer. An error is returned if the placement cannot be created.
+func (p *Plugin) createPlacement(policyConf *types.PolicyConfig) (
 	name string, err error,
 ) {
 	plrPath := policyConf.Placement.PlacementRulePath
-	var rule map[string]interface{}
-	// If a path to a placement rule is provided, find the placement rule and reuse it.
-	if plrPath != "" {
-		name, rule, err = p.getPlrFromPath(plrPath)
+	plcPath := policyConf.Placement.PlacementPath
+	var placement map[string]interface{}
+	// If a path to a placement is provided, find the placement and reuse it.
+	if plrPath != "" || plcPath != "" {
+		var resolvedPlPath string
+		if plrPath != "" {
+			resolvedPlPath = plrPath
+		} else {
+			resolvedPlPath = plcPath
+		}
+		name, placement, err = p.getPlcFromPath(resolvedPlPath)
 		if err != nil {
 			return
 		}
 
-		// processedPlrs keeps track of which placement rules have been seen by name. This is so
-		// that if the same placementRulePath is provided for multiple policies, it's not reincluded
+		// processedPlcs keeps track of which placements have been seen by name. This is so
+		// that if the same placement path is provided for multiple policies, it's not re-included
 		// in the generated output of the plugin.
-		if p.processedPlrs[name] {
+		if p.processedPlcs[name] {
 			return
 		}
 
-		p.processedPlrs[name] = true
+		p.processedPlcs[name] = true
 	} else {
 		var skip bool
-		name, skip = p.getPlrName(policyConf)
+		name, skip = p.getPlcName(policyConf)
 		if skip {
 			return
 		}
 
+		// Determine which selectors to use
+		var resolvedSelectors map[string]string
+		if len(policyConf.Placement.ClusterSelectors) > 0 {
+			resolvedSelectors = policyConf.Placement.ClusterSelectors
+		} else if len(policyConf.Placement.LabelSelector) > 0 {
+			resolvedSelectors = policyConf.Placement.LabelSelector
+		}
+
 		// Sort the keys so that the match expressions can be ordered based on the label name
-		keys := make([]string, 0, len(policyConf.Placement.ClusterSelectors))
-		for key := range policyConf.Placement.ClusterSelectors {
+		keys := make([]string, 0, len(resolvedSelectors))
+		for key := range resolvedSelectors {
 			keys = append(keys, key)
 		}
 		sort.Strings(keys)
@@ -554,62 +683,84 @@ func (p *Plugin) createPlacementRule(policyConf *types.PolicyConfig) (
 			matchExpression := map[string]interface{}{
 				"key": label,
 			}
-			if policyConf.Placement.ClusterSelectors[label] == "" {
+			if resolvedSelectors[label] == "" {
 				matchExpression["operator"] = "Exist"
 			} else {
 				matchExpression["operator"] = "In"
-				matchExpression["values"] = []string{policyConf.Placement.ClusterSelectors[label]}
+				matchExpression["values"] = []string{resolvedSelectors[label]}
 			}
 			matchExpressions = append(matchExpressions, matchExpression)
 		}
 
-		rule = map[string]interface{}{
-			"apiVersion": placementRuleAPIVersion,
-			"kind":       placementRuleKind,
-			"metadata": map[string]interface{}{
-				"name":      name,
-				"namespace": p.PolicyDefaults.Namespace,
-			},
-			"spec": map[string]interface{}{
-				"clusterConditions": []map[string]string{
-					{"status": "True", "type": "ManagedClusterConditionAvailable"},
+		if p.usingPlR {
+			placement = map[string]interface{}{
+				"apiVersion": placementRuleAPIVersion,
+				"kind":       placementRuleKind,
+				"metadata": map[string]interface{}{
+					"name":      name,
+					"namespace": p.PolicyDefaults.Namespace,
 				},
-				"clusterSelector": map[string]interface{}{
-					"matchExpressions": matchExpressions,
+				"spec": map[string]interface{}{
+					"clusterConditions": []map[string]string{
+						{"status": "True", "type": "ManagedClusterConditionAvailable"},
+					},
+					"clusterSelector": map[string]interface{}{
+						"matchExpressions": matchExpressions,
+					},
 				},
-			},
+			}
+		} else {
+			placement = map[string]interface{}{
+				"apiVersion": placementAPIVersion,
+				"kind":       placementKind,
+				"metadata": map[string]interface{}{
+					"name":      name,
+					"namespace": p.PolicyDefaults.Namespace,
+				},
+				"spec": map[string]interface{}{
+					"predicates": []map[string]interface{}{
+						{
+							"requiredClusterSelector": map[string]interface{}{
+								"labelSelector": map[string]interface{}{
+									"matchExpressions": matchExpressions,
+								},
+							},
+						},
+					},
+				},
+			}
 		}
 
 		csKey := getCsKey(policyConf)
-		p.csToPlr[csKey] = name
+		p.csToPlc[csKey] = name
 	}
 
-	if p.allPlrs[name] {
-		return "", fmt.Errorf("a duplicate placement rule name was detected: %s", name)
+	if p.allPlcs[name] {
+		return "", fmt.Errorf("a duplicate placement name was detected: %s", name)
 	}
-	p.allPlrs[name] = true
+	p.allPlcs[name] = true
 
-	var ruleYAML []byte
-	ruleYAML, err = yaml.Marshal(rule)
+	var placementYAML []byte
+	placementYAML, err = yaml.Marshal(placement)
 	if err != nil {
 		err = fmt.Errorf(
-			"an unexpected error occurred when converting the placement rule to YAML: %w", err,
+			"an unexpected error occurred when converting the placement to YAML: %w", err,
 		)
 
 		return
 	}
 
 	p.outputBuffer.Write([]byte("---\n"))
-	p.outputBuffer.Write(ruleYAML)
+	p.outputBuffer.Write(placementYAML)
 
 	return
 }
 
-// createPlacementBinding creates a placement binding for the input placement rule and policies by
+// createPlacementBinding creates a placement binding for the input placement and policies by
 // writing it to the policy generator's output buffer. An error is returned if the placement binding
 // cannot be created.
 func (p *Plugin) createPlacementBinding(
-	bindingName, plrName string, policyConfs []*types.PolicyConfig,
+	bindingName, plcName string, policyConfs []*types.PolicyConfig,
 ) error {
 	subjects := make([]map[string]string, 0, len(policyConfs))
 	for _, policyConf := range policyConfs {
@@ -622,6 +773,16 @@ func (p *Plugin) createPlacementBinding(
 		subjects = append(subjects, subject)
 	}
 
+	var resolvedPlcKind string
+	var resolvedPlcAPIVersion string
+	if p.usingPlR {
+		resolvedPlcKind = placementRuleKind
+		resolvedPlcAPIVersion = placementRuleAPIVersion
+	} else {
+		resolvedPlcKind = placementKind
+		resolvedPlcAPIVersion = placementAPIVersion
+	}
+
 	binding := map[string]interface{}{
 		"apiVersion": placementBindingAPIVersion,
 		"kind":       placementBindingKind,
@@ -631,9 +792,9 @@ func (p *Plugin) createPlacementBinding(
 		},
 		"placementRef": map[string]string{
 			// Remove the version at the end
-			"apiGroup": strings.Split(placementRuleAPIVersion, "/")[0],
-			"name":     plrName,
-			"kind":     placementRuleKind,
+			"apiGroup": strings.Split(resolvedPlcAPIVersion, "/")[0],
+			"name":     plcName,
+			"kind":     resolvedPlcKind,
 		},
 		"subjects": subjects,
 	}

--- a/internal/plugin_test.go
+++ b/internal/plugin_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -16,7 +17,11 @@ func TestGenerate(t *testing.T) {
 	tmpDir := t.TempDir()
 	createConfigMap(t, tmpDir, "configmap.yaml")
 	p := Plugin{}
-	p.baseDirectory = tmpDir
+	var err error
+	p.baseDirectory, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 	p.PlacementBindingDefaults.Name = "my-placement-binding"
 	p.PolicyDefaults.Placement.Name = "my-placement-rule"
 	p.PolicyDefaults.Namespace = "my-policies"
@@ -159,7 +164,11 @@ func TestGenerateSeparateBindings(t *testing.T) {
 	tmpDir := t.TempDir()
 	createConfigMap(t, tmpDir, "configmap.yaml")
 	p := Plugin{}
-	p.baseDirectory = tmpDir
+	var err error
+	p.baseDirectory, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 	p.PolicyDefaults.Namespace = "my-policies"
 	policyConf := types.PolicyConfig{
 		Name: "policy-app-config",
@@ -307,7 +316,11 @@ func TestGenerateMissingBindingName(t *testing.T) {
 	tmpDir := t.TempDir()
 	createConfigMap(t, tmpDir, "configmap.yaml")
 	p := Plugin{}
-	p.baseDirectory = tmpDir
+	var err error
+	p.baseDirectory, err = filepath.EvalSymlinks(tmpDir)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
 	p.PlacementBindingDefaults.Name = ""
 	p.PolicyDefaults.Placement.Name = "my-placement-rule"
 	p.PolicyDefaults.Namespace = "my-policies"
@@ -329,7 +342,7 @@ func TestGenerateMissingBindingName(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	_, err := p.Generate()
+	_, err = p.Generate()
 	if err == nil {
 		t.Fatal("Expected an error but did not get one")
 	}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -14,7 +14,9 @@ type NamespaceSelector struct {
 
 type PlacementConfig struct {
 	ClusterSelectors  map[string]string `json:"clusterSelectors,omitempty" yaml:"clusterSelectors,omitempty"`
+	LabelSelector     map[string]string `json:"labelSelector,omitempty" yaml:"labelSelector,omitempty"`
 	Name              string            `json:"name,omitempty" yaml:"name,omitempty"`
+	PlacementPath     string            `json:"placementPath,omitempty" yaml:"placementPath,omitempty"`
 	PlacementRulePath string            `json:"placementRulePath,omitempty" yaml:"placementRulePath,omitempty"`
 }
 

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -290,6 +290,10 @@ func verifyManifestPath(baseDirectory string, manifestPath string) error {
 	if err != nil {
 		return fmt.Errorf("could not resolve the manifest path %s to an absolute path", manifestPath)
 	}
+	absPath, err = filepath.EvalSymlinks(absPath)
+	if err != nil {
+		return fmt.Errorf("could not resolve symlinks to the manifest path %s", manifestPath)
+	}
 
 	relPath, err := filepath.Rel(baseDirectory, absPath)
 	if err != nil {


### PR DESCRIPTION
Sync changes from:
- https://github.com/open-cluster-management-io/ocm-kustomize-generator-plugins/pull/3

I may need to look at it more in-depth to make sure the logic flows work, but I think it boils down to this one-line change that did it (it was formerly checking for `plCount.plr != 0`), and it appears to work:
```go
p.usingPlR = plCount.plc == 0
```
